### PR TITLE
fix(windows): remove windows_subsystem from plugin-host to enable CLAP scan

### DIFF
--- a/plugin-host/src/main.rs
+++ b/plugin-host/src/main.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(windows, windows_subsystem = "windows")]
-
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;


### PR DESCRIPTION
On Windows, '#![windows_subsystem = "windows"]' suppresses stdout/stderr
for the plugin-host binary. This causes the CLAP/VST3 scanner JSON output
to be discarded, resulting in 'failed to parse scan JSON' errors.

The plugin-host is a CLI tool spawned by the main DAW process -- it does not
need the GUI subsystem. Removing the attribute restores stdout and fixes
plugin scanning on Windows.

Tested: 21 CLAP plugins found on Windows 11 with the fix applied.
